### PR TITLE
Parse list of params

### DIFF
--- a/script/src/CliMonad.elm
+++ b/script/src/CliMonad.elm
@@ -250,7 +250,7 @@ messageToString { path, message } =
 objectToAnnotation : { useMaybe : Bool } -> Object -> CliMonad Elm.Annotation.Annotation
 objectToAnnotation config fields =
     FastDict.toList fields
-        |> combineMap (\( k, v ) -> map (Tuple.pair k) (fieldToAnnotation config v))
+        |> combineMap (\( k, v ) -> map (Tuple.pair (Common.toValueName k)) (fieldToAnnotation config v))
         |> map recordType
 
 

--- a/script/src/Common.elm
+++ b/script/src/Common.elm
@@ -15,6 +15,8 @@ typifyName name =
         |> Maybe.map (\( first, rest ) -> String.cons first (String.replace "-" " " rest))
         |> Maybe.withDefault ""
         |> String.replace "_" " "
+        |> String.replace "(" " "
+        |> String.replace ")" " "
         |> String.Extra.toTitleCase
         |> String.replace " " ""
         |> deSymbolify

--- a/script/src/Common.elm
+++ b/script/src/Common.elm
@@ -39,7 +39,19 @@ toValueName name =
     name
         |> deSymbolify
         |> String.uncons
-        |> Maybe.map (\( first, rest ) -> String.cons (Char.toLower first) (String.replace "-" "_" rest))
+        |> Maybe.map
+            (\( first, rest ) ->
+                let
+                    replaced : String
+                    replaced =
+                        String.replace "-" "_" rest
+                in
+                if first == '_' then
+                    replaced
+
+                else
+                    String.cons (Char.toLower first) replaced
+            )
         |> Maybe.withDefault ""
 
 


### PR DESCRIPTION
Parse list of query params to allow generating endpoints like                https://api.github.com/user/migrations/{migration_id}

```elm
{-| Fetches a single user migration. The response includes the `state` of the migration, which can be one of the following values:

*   `pending` - the migration hasn't started yet.
*   `exporting` - the migration is in progress.
*   `exported` - the migration finished successfully.
*   `failed` - the migration failed.

Once the migration has been `exported` you can [download the migration archive](https://docs.github.com/rest/reference/migrations#download-a-user-migration-archive).
-}
migrationsGetStatusForAuthenticatedUser :
    { toMsg : Result Http.Error Migration -> msg
    , params : { migration_id : Int, exclude : Maybe (List String) }
    }
    -> Cmd msg
migrationsGetStatusForAuthenticatedUser config =
    Http.request
        { method = "GET"
        , headers = []
        , expect = Http.expectJson config.toMsg decodeMigration
        , body = Http.emptyBody
        , timeout = Nothing
        , tracker = Nothing
        , url =
            Url.Builder.crossOrigin
                (String.replace
                    "{migration_id}"
                    config.params.migration_id
                    "https://api.github.com/user/migrations/{migration_id}"
                )
                []
                (List.filterMap
                    Basics.identity
                    [ Maybe.map
                        (Url.Builder.string "exclude")
                        config.params.exclude
                    ]
                )
        }
```